### PR TITLE
Add category filtering to payee chart

### DIFF
--- a/ByPayee.html
+++ b/ByPayee.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <h1>YNAB Transactions by Payee</h1>
+<div id="categoryFilter"></div>
 <canvas id="payeeChart"></canvas>
 <script src="chart.min.js"></script>
 <script src="bypayee.js"></script>

--- a/bypayee.css
+++ b/bypayee.css
@@ -15,3 +15,17 @@ h1 {
     flex: 1;
     width: 100%;
 }
+
+#categoryFilter {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px;
+    margin: 0 20px 10px;
+}
+
+#categoryFilter label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}


### PR DESCRIPTION
## Summary
- add category filter section to the page
- style filter controls
- remove legend from chart and update dynamically
- derive categories from CSV and allow slicer by category

## Testing
- `python3 -m py_compile server.py`
- `node --check bypayee.js`


------
https://chatgpt.com/codex/tasks/task_e_6862d847760883268c0525a5cdc47c3e