### PR TITLE
Improve chart responsiveness

### DIFF
--- a/ByPayee.html
+++ b/ByPayee.html
@@ -7,10 +7,12 @@
 </head>
 <body>
 <h1>YNAB Transactions by Payee</h1>
-<div id="container">
-  <div id="categoryFilter"></div>
-  <canvas id="payeeChart"></canvas>
-</div>
+  <div id="container">
+    <div id="categoryFilter"></div>
+    <div id="chartWrapper">
+      <canvas id="payeeChart"></canvas>
+    </div>
+  </div>
 <script src="chart.min.js"></script>
 <script src="bypayee.js"></script>
 </body>

--- a/bypayee.css
+++ b/bypayee.css
@@ -4,22 +4,34 @@ body {
     height: 100vh;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 }
 
 #container {
     display: flex;
     flex: 1;
+    overflow: hidden;
 }
 
 h1 {
     text-align: center;
-    margin: 20px;
+    margin: 20px 0;
+}
+
+#chartWrapper {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
 }
 
 #payeeChart {
-    flex: 1;
-    width: auto;
-    min-width: 0;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    aspect-ratio: 1 / 1;
 }
 
 #categoryFilter {

--- a/bypayee.js
+++ b/bypayee.js
@@ -24,6 +24,18 @@ let inIndex;
 let categoryIndex;
 let groupIndex;
 
+function resizeCanvas() {
+    const wrapper = document.getElementById('chartWrapper');
+    const canvas = document.getElementById('payeeChart');
+    if (!wrapper || !canvas) return;
+    const size = Math.min(wrapper.clientWidth, wrapper.clientHeight);
+    canvas.width = size;
+    canvas.height = size;
+    if (chart) {
+        chart.resize();
+    }
+}
+
 function loadChart() {
     fetch('transactions.csv')
         .then(res => res.text())
@@ -42,6 +54,7 @@ function loadChart() {
             groupIndex = headers.indexOf('Category Group');
             createCategoryFilter();
             updateChart();
+            resizeCanvas();
         });
 }
 
@@ -80,6 +93,7 @@ function createCategoryFilter() {
 }
 
 function updateChart() {
+    resizeCanvas();
     const selected = Array.from(document.querySelectorAll('#categoryFilter input:checked')).map(cb => cb.value);
     if (selected.length === 0) {
         if (chart) {
@@ -157,3 +171,4 @@ const labelPlugin = {
 };
 
 document.addEventListener('DOMContentLoaded', loadChart);
+window.addEventListener('resize', resizeCanvas);


### PR DESCRIPTION
## Summary
- add wrapper around canvas
- ensure body and container don't overflow
- keep chart square using JS resize logic

## Testing
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6862de4d8ee88326bf6ce6961e579f64